### PR TITLE
Fix no username bug

### DIFF
--- a/src/emqx_web_hook.erl
+++ b/src/emqx_web_hook.erl
@@ -278,7 +278,9 @@ with_filter(Fun, Msg, Topic, Filter) ->
 format_from(Message = #message{from = From}) when is_atom(From) ->
     format_from(Message#message{from = a2b(From)});
 format_from(#message{from = ClientId, headers = #{username := Username}}) ->
-    {ClientId, Username}.
+    {ClientId, Username};
+format_from(#message{from = ClientId}) ->
+    {ClientId, <<>>}.
 
 a2b(A) -> erlang:atom_to_binary(A, utf8).
 

--- a/src/emqx_web_hook.erl
+++ b/src/emqx_web_hook.erl
@@ -275,14 +275,13 @@ with_filter(Fun, Msg, Topic, Filter) ->
         false -> {ok, Msg}
     end.
 
-format_from(Message = #message{from = From}) when is_atom(From) ->
+format_from(Message = #message{from = From}) ->
     format_from(Message#message{from = a2b(From)});
 format_from(#message{from = ClientId, headers = #{username := Username}}) ->
-    {ClientId, Username};
-format_from(#message{from = ClientId}) ->
-    {ClientId, <<>>}.
+    {a2b(ClientId), a2b(Username)}.
 
-a2b(A) -> erlang:atom_to_binary(A, utf8).
+a2b(A) when is_atom(A) -> erlang:atom_to_binary(A, utf8);
+a2b(A) -> A.
 
 load_(Hook, Fun, Filter, Params) ->
     case Hook of


### PR DESCRIPTION
Prior to this change, if the message without username is passed into the `format_from` function, it can not match the function `format_from`. This change add new function clause to catch the situation that message contains no username.