### PR TITLE
Add a option to encode payload field

### DIFF
--- a/etc/emqx_web_hook.conf
+++ b/etc/emqx_web_hook.conf
@@ -1,12 +1,12 @@
 
 web.hook.api.url = http://127.0.0.1:8080
 
-## Encode message payload field with base64
+## Encode message payload field
 ##
-## Value: true | false
+## Value: base64 | base62
 ##
-## Default: false
-## web.hook.encode_payload = false
+## Default: undefined
+## web.hook.encode_payload = base64
 
 web.hook.rule.client.connected.1     = {"action": "on_client_connected"}
 web.hook.rule.client.disconnected.1  = {"action": "on_client_disconnected"}

--- a/etc/emqx_web_hook.conf
+++ b/etc/emqx_web_hook.conf
@@ -1,6 +1,13 @@
 
 web.hook.api.url = http://127.0.0.1:8080
 
+## Encode message payload field with base64
+##
+## Value: true | false
+##
+## Default: false
+## web.hook.encode_payload = false
+
 web.hook.rule.client.connected.1     = {"action": "on_client_connected"}
 web.hook.rule.client.disconnected.1  = {"action": "on_client_disconnected"}
 web.hook.rule.client.subscribe.1     = {"action": "on_client_subscribe"}

--- a/priv/emqx_web_hook.schema
+++ b/priv/emqx_web_hook.schema
@@ -1,5 +1,13 @@
+%%-*- mode: erlang -*-
+%% EMQ X R3.0 config mapping
+
 {mapping, "web.hook.api.url", "emqx_web_hook.url", [
   {datatype, string}
+]}.
+
+{mapping, "web.hook.encode_payload", "emqx_web_hook.encode_payload", [
+  {default, false},
+  {datatype, {enum, [true, false]}}
 ]}.
 
 {mapping, "web.hook.rule.client.connected.$name", "emqx_web_hook.rules", [

--- a/priv/emqx_web_hook.schema
+++ b/priv/emqx_web_hook.schema
@@ -6,8 +6,8 @@
 ]}.
 
 {mapping, "web.hook.encode_payload", "emqx_web_hook.encode_payload", [
-  {default, false},
-  {datatype, {enum, [true, false]}}
+  {default, undefined},
+  {datatype, {enum, [base62, base64]}}
 ]}.
 
 {mapping, "web.hook.rule.client.connected.$name", "emqx_web_hook.rules", [

--- a/src/emqx_web_hook.erl
+++ b/src/emqx_web_hook.erl
@@ -298,10 +298,11 @@ format_from(#message{from = ClientId, headers = _HeadersNoUsername}) ->
     {a2b(ClientId), <<"undefined">>}.
 
 encode_payload(Payload) ->
-    case application:get_env(?APP, encode_payload, false) of
-        false -> Payload;
-        true  -> base64:encode(Payload)
-    end.
+    encode_payload(Payload, application:get_env(?APP, encode_payload, undefined)).
+
+encode_payload(Payload, base62) -> emqx_base62:encode(Payload);
+encode_payload(Payload, base64) -> base64:encode(Payload);
+encode_payload(Payload, _) -> Payload.
 
 a2b(A) when is_atom(A) -> erlang:atom_to_binary(A, utf8);
 a2b(A) -> A.

--- a/src/emqx_web_hook.erl
+++ b/src/emqx_web_hook.erl
@@ -196,7 +196,7 @@ on_message_publish(Message = #message{topic = Topic, flags = #{retain := Retain}
                   {topic, Message#message.topic},
                   {qos, Message#message.qos},
                   {retain, Retain},
-                  {payload, Message#message.payload},
+                  {payload, encode_payload(Message#message.payload)},
                   {ts, emqx_time:now_secs(Message#message.timestamp)}],
         send_http_request(Params),
         {ok, Message}
@@ -218,7 +218,7 @@ on_message_deliver(#{client_id := ClientId, username := Username}, Message = #me
                 {topic, Message#message.topic},
                 {qos, Message#message.qos},
                 {retain, Retain},
-                {payload, Message#message.payload},
+                {payload, encode_payload(Message#message.payload)},
                 {ts, emqx_time:now_secs(Message#message.timestamp)}],
       send_http_request(Params)
     end, Topic, Filter).
@@ -238,7 +238,7 @@ on_message_acked(#{client_id := ClientId}, Message = #message{topic = Topic, fla
                   {topic, Message#message.topic},
                   {qos, Message#message.qos},
                   {retain, Retain},
-                  {payload, Message#message.payload},
+                  {payload, encode_payload(Message#message.payload)},
                   {ts, emqx_time:now_secs(Message#message.timestamp)}],
         send_http_request(Params)
       end, Topic, Filter).
@@ -296,6 +296,12 @@ format_from(#message{from = ClientId, headers = #{username := Username}}) ->
     {a2b(ClientId), a2b(Username)};
 format_from(#message{from = ClientId, headers = _HeadersNoUsername}) ->
     {a2b(ClientId), <<"undefined">>}.
+
+encode_payload(Payload) ->
+    case application:get_env(?APP, encode_payload, false) of
+        false -> Payload;
+        true  -> base64:encode(Payload)
+    end.
 
 a2b(A) when is_atom(A) -> erlang:atom_to_binary(A, utf8);
 a2b(A) -> A.


### PR DESCRIPTION
For: https://github.com/emqx/emqx-web-hook/issues/103

Now, we can specify a method to encode payload field:
```
## Encode message payload field
##
## Value: base64 | base62
##
## Default: undefined
## web.hook.encode_payload = base64
```